### PR TITLE
updated select only month and year

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ allprojects {
 Step 2. Add the dependency
 ```groovy
 dependencies {
-    implementation 'com.github.aliab:Persian-Date-Picker-Dialog:1.7.0'
+    implementation 'com.github.aliab:Persian-Date-Picker-Dialog:1.7.1'
 }
 ```
 

--- a/app/src/main/java/ir/hamsaa/MainActivity.java
+++ b/app/src/main/java/ir/hamsaa/MainActivity.java
@@ -47,7 +47,9 @@ public class MainActivity extends AppCompatActivity {
                 .setInitDate(1370, 3, 13)
                 .setActionTextColor(Color.GRAY)
                 .setTypeFace(typeface)
-                .setTitleType(PersianDatePickerDialog.WEEKDAY_DAY_MONTH_YEAR)
+                .setShowDayPicker(false)
+
+                .setTitleType(PersianDatePickerDialog.MONTH_YEAR)
                 .setShowInBottomSheet(true)
                 .setListener(new PersianPickerListener() {
                     @Override
@@ -88,7 +90,9 @@ public class MainActivity extends AppCompatActivity {
                 .setTitleColor(Color.WHITE)
                 .setActionTextColor(Color.RED)
                 .setPickerBackgroundDrawable(R.drawable.darkmode_bg)
-                .setTitleType(PersianDatePickerDialog.DAY_MONTH_YEAR)
+                .setTitleType(PersianDatePickerDialog.MONTH_YEAR)
+                .setShowDayPicker(false)
+
                 .setCancelable(false)
                 .setListener(new Listener() {
                     @Override

--- a/persiandatepicker/src/main/java/ir/hamsaa/persiandatepicker/PersianDatePicker.java
+++ b/persiandatepicker/src/main/java/ir/hamsaa/persiandatepicker/PersianDatePicker.java
@@ -167,6 +167,16 @@ class PersianDatePicker extends LinearLayout {
         updateViewData();
     }
 
+    public void setDayVisibility(boolean visibility) {
+        if (visibility) {
+            dayNumberPicker.setVisibility(View.VISIBLE);
+        }else {
+            dayNumberPicker.setVisibility(View.GONE);
+        }
+
+        invalidate();
+    }
+
     public void setTypeFace(Typeface typeFace) {
         this.typeFace = typeFace;
         updateViewData();

--- a/persiandatepicker/src/main/java/ir/hamsaa/persiandatepicker/PersianDatePickerDialog.java
+++ b/persiandatepicker/src/main/java/ir/hamsaa/persiandatepicker/PersianDatePickerDialog.java
@@ -39,6 +39,7 @@ public class PersianDatePickerDialog {
     public static final int NO_TITLE = 0;
     public static final int DAY_MONTH_YEAR = 1;
     public static final int WEEKDAY_DAY_MONTH_YEAR = 2;
+    public static final int MONTH_YEAR = 3;
 
     private Context context;
     private String positiveButtonString = "تایید";
@@ -61,6 +62,7 @@ public class PersianDatePickerDialog {
     private int titleColor = Color.parseColor("#111111");
     private boolean cancelable = true;
     private boolean forceMode;
+    private boolean isShowDayPicker = true;
     private int pickerBackgroundColor;
     private int pickerBackgroundDrawable;
     private int titleType = 0;
@@ -180,6 +182,11 @@ public class PersianDatePickerDialog {
         return this;
     }
 
+    public PersianDatePickerDialog setShowDayPicker(boolean showDayPicker) {
+        this.isShowDayPicker = showDayPicker;
+        return this;
+    }
+
     public PersianDatePickerDialog setTodayTextSize(int sizeInt) {
         this.todayTextSize = sizeInt;
         return this;
@@ -270,7 +277,7 @@ public class PersianDatePickerDialog {
 
         container.setBackgroundColor(backgroundColor);
         dateText.setTextColor(titleColor);
-
+        datePickerView.setDayVisibility(isShowDayPicker);
 
         if (pickerBackgroundColor != 0) {
             datePickerView.setBackgroundColor(pickerBackgroundColor);
@@ -436,6 +443,11 @@ public class PersianDatePickerDialog {
                 date = persianDate.getPersianDayOfWeekName() + " " +
                         persianDate.getPersianDay() + " " +
                         persianDate.getPersianMonthName() + " " +
+                        persianDate.getPersianYear();
+                dateText.setText(PersianHelper.toPersianNumber(date));
+                break;
+            case MONTH_YEAR:
+                date = persianDate.getPersianMonthName() + " " +
                         persianDate.getPersianYear();
 
                 dateText.setText(PersianHelper.toPersianNumber(date));


### PR DESCRIPTION
added feature to select and display only month and year with help of [mr siavash-sajjad](https://github.com/siavash-sajjad) [code](https://github.com/siavash-sajjad/Persian-Date-Picker-Dialog/commit/e83564d49778b9acbe190e4f42637f720aaa489d)

to  set dialog to display only month and year create instance with

 ```

                .setShowDayPicker(false)
                .setTitleType(PersianDatePickerDialog.MONTH_YEAR)
//(instead of   `.setTitleType(PersianDatePickerDialog.WEEKDAY_DAY_MONTH_YEAR)`) 
```

**NOTE THAT** i have used this method in my **MainActivity.java** and if your wont change these line when accepting pull will affect your main sample, and instead should use README.md file to introduce this property