### PR TITLE
Feature: customize dates text size and added states for date editing

### DIFF
--- a/app/src/main/java/ir/hamsaa/MainActivity.java
+++ b/app/src/main/java/ir/hamsaa/MainActivity.java
@@ -42,6 +42,8 @@ public class MainActivity extends AppCompatActivity {
                 .setTodayButtonVisible(true)
                 .setMinYear(1300)
                 .setAllButtonsTextSize(12)
+                .setDisableDatesEditing(true)
+                .setTitleTextSize(16)
                 .setMaxYear(1500)
                 .setInitDate(1370, 3, 13)
                 .setActionTextColor(Color.GRAY)

--- a/persiandatepicker/src/main/java/ir/hamsaa/persiandatepicker/PersianDatePickerDialog.java
+++ b/persiandatepicker/src/main/java/ir/hamsaa/persiandatepicker/PersianDatePickerDialog.java
@@ -58,7 +58,9 @@ public class PersianDatePickerDialog {
     private int actionTextSize = 12;
     private int negativeTextSize = 12;
     private int todayTextSize = 12;
+    private int titleTextSize = 12;
     public static int datesTextSize = 12;
+    public static boolean disableDatesEditing = false;
     private int backgroundColor = Color.WHITE;
     private int titleColor = Color.parseColor("#111111");
     private boolean cancelable = true;
@@ -198,6 +200,11 @@ public class PersianDatePickerDialog {
         return this;
     }
 
+    public PersianDatePickerDialog setDisableDatesEditing(boolean isDisable) {
+        PersianDatePickerDialog.disableDatesEditing = isDisable;
+        return this;
+    }
+
     public PersianDatePickerDialog setNegativeButton(String negativeButton) {
         this.negativeButtonString = negativeButton;
         return this;
@@ -210,6 +217,11 @@ public class PersianDatePickerDialog {
 
     public PersianDatePickerDialog setNegativeTextSize(int sizeInt) {
         this.negativeTextSize = sizeInt;
+        return this;
+    }
+
+    public PersianDatePickerDialog setTitleTextSize(int sizeInt) {
+        this.titleTextSize = sizeInt;
         return this;
     }
 
@@ -432,6 +444,8 @@ public class PersianDatePickerDialog {
     }
 
     private void updateView(TextView dateText, PersianPickerDate persianDate) {
+        dateText.setTextSize(titleTextSize);
+
         String date;
         switch (titleType) {
             case NO_TITLE:

--- a/persiandatepicker/src/main/java/ir/hamsaa/persiandatepicker/PersianDatePickerDialog.java
+++ b/persiandatepicker/src/main/java/ir/hamsaa/persiandatepicker/PersianDatePickerDialog.java
@@ -58,6 +58,7 @@ public class PersianDatePickerDialog {
     private int actionTextSize = 12;
     private int negativeTextSize = 12;
     private int todayTextSize = 12;
+    public static int datesTextSize = 12;
     private int backgroundColor = Color.WHITE;
     private int titleColor = Color.parseColor("#111111");
     private boolean cancelable = true;
@@ -189,6 +190,11 @@ public class PersianDatePickerDialog {
 
     public PersianDatePickerDialog setTodayTextSize(int sizeInt) {
         this.todayTextSize = sizeInt;
+        return this;
+    }
+
+    public PersianDatePickerDialog setDatesTextSize(int sizeInt) {
+        PersianDatePickerDialog.datesTextSize = sizeInt;
         return this;
     }
 

--- a/persiandatepicker/src/main/java/ir/hamsaa/persiandatepicker/view/PersianNumberPicker.java
+++ b/persiandatepicker/src/main/java/ir/hamsaa/persiandatepicker/view/PersianNumberPicker.java
@@ -59,6 +59,9 @@ public class PersianNumberPicker extends NumberPicker {
                 ((TextView) view).setTypeface(PersianDatePickerDialog.typeFace);
 
             ((TextView) view).setTextSize(PersianDatePickerDialog.datesTextSize);
+
+            if (PersianDatePickerDialog.disableDatesEditing)
+                setDescendantFocusability(NumberPicker.FOCUS_BLOCK_DESCENDANTS);
         }
     }
 

--- a/persiandatepicker/src/main/java/ir/hamsaa/persiandatepicker/view/PersianNumberPicker.java
+++ b/persiandatepicker/src/main/java/ir/hamsaa/persiandatepicker/view/PersianNumberPicker.java
@@ -4,12 +4,8 @@ import android.content.Context;
 import android.graphics.Typeface;
 import android.util.AttributeSet;
 import android.view.View;
-import android.widget.EditText;
 import android.widget.NumberPicker;
 import android.widget.TextView;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import ir.hamsaa.persiandatepicker.PersianDatePickerDialog;
 
@@ -61,6 +57,8 @@ public class PersianNumberPicker extends NumberPicker {
         if (view instanceof TextView) {
             if (PersianDatePickerDialog.typeFace != null)
                 ((TextView) view).setTypeface(PersianDatePickerDialog.typeFace);
+
+            ((TextView) view).setTextSize(PersianDatePickerDialog.datesTextSize);
         }
     }
 


### PR DESCRIPTION
We added more customization tools into `Persian-Date-Picker`!  This PR contains two important missing features which gives people more control over this great library. I hope you review and add these into `master` branch to make it publicly available.

##### Text Size
`.setDatesTextSize(int)` helps you to manipulate the default date text size!
`.setTitleTextSize(int)` helps you to manipulate the titles text size!

##### Date Editing
`.setDisableDatesEditing(boolean)` helps you to disable dates editing via keyboard!