### PR TITLE
Add support for Dari and Pashto

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "ir.hamsaa.persiandatepicker"
         minSdkVersion libraryMinSdk
         targetSdkVersion libraryTargetSdk
-        versionCode 9
-        versionName "1.6.0"
+        versionCode 10
+        versionName "1.8.0"
     }
     buildTypes {
         release {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "ir.hamsaa.persiandatepicker"
         minSdkVersion libraryMinSdk
         targetSdkVersion libraryTargetSdk
-        versionCode 10
-        versionName "1.8.0"
+        versionCode 9
+        versionName "1.6.0"
     }
     buildTypes {
         release {

--- a/persiandatepicker/src/main/java/ir/hamsaa/persiandatepicker/PersianDatePicker.java
+++ b/persiandatepicker/src/main/java/ir/hamsaa/persiandatepicker/PersianDatePicker.java
@@ -17,7 +17,10 @@ import android.widget.TextView;
 import androidx.annotation.ColorInt;
 import androidx.annotation.DrawableRes;
 
+import java.lang.reflect.Array;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 import ir.hamsaa.persiandatepicker.api.PersianPickerDate;
 import ir.hamsaa.persiandatepicker.date.PersianDateImpl;
@@ -50,6 +53,8 @@ class PersianDatePicker extends LinearLayout {
     private Typeface typeFace;
     private int dividerColor;
     private int yearRange;
+
+    public List<String> monthNamesFromStrings = new ArrayList();
 
     public PersianDatePicker(Context context) {
         this(context, null, -1);
@@ -99,6 +104,9 @@ class PersianDatePicker extends LinearLayout {
         // update variables from xml
         updateVariablesFromXml(context, attrs);
 
+        //Update constant from string resources
+        updateConstantsFromStrings();
+
         // update view
         updateViewData();
     }
@@ -133,6 +141,22 @@ class PersianDatePicker extends LinearLayout {
         }
 
         a.recycle();
+    }
+
+    void updateConstantsFromStrings(){
+        monthNamesFromStrings.add(getContext().getString(R.string.farvardin));
+        monthNamesFromStrings.add(getContext().getString(R.string.ordibehesht));
+        monthNamesFromStrings.add(getContext().getString(R.string.khordad));
+        monthNamesFromStrings.add(getContext().getString(R.string.tir));
+        monthNamesFromStrings.add(getContext().getString(R.string.mordad));
+        monthNamesFromStrings.add(getContext().getString(R.string.shahrivar));
+        monthNamesFromStrings.add(getContext().getString(R.string.mehr));
+        monthNamesFromStrings.add(getContext().getString(R.string.aban));
+        monthNamesFromStrings.add(getContext().getString(R.string.azar));
+        monthNamesFromStrings.add(getContext().getString(R.string.dey));
+        monthNamesFromStrings.add(getContext().getString(R.string.bahman));
+        monthNamesFromStrings.add(getContext().getString(R.string.esfand));
+
     }
 
     public void setBackgroundColor(@ColorInt int color) {
@@ -234,7 +258,7 @@ class PersianDatePicker extends LinearLayout {
         monthNumberPicker.setMinValue(1);
         monthNumberPicker.setMaxValue(maxMonth > 0 ? maxMonth : 12);
         if (displayMonthNames) {
-            monthNumberPicker.setDisplayedValues(PersianCalendarConstants.persianMonthNames);
+            monthNumberPicker.setDisplayedValues(monthNamesFromStrings.toArray(new String[0]));
         }
 
         if (selectedMonth < 1 || selectedMonth > 12) {

--- a/persiandatepicker/src/main/res/values-fa-rAF/strings.xml
+++ b/persiandatepicker/src/main/res/values-fa-rAF/strings.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <string name="app_name">PersianDatePicker</string>
+
+    <string name="farvardin">حمل</string>
+    <string name="ordibehesht">ثور</string>
+    <string name="khordad">جوزا</string>
+    <string name="tir">سرطان</string>
+    <string name="mordad">اسد</string>
+    <string name="shahrivar">سنبله</string>
+    <string name="mehr">میزان</string>
+    <string name="aban">عقرب</string>
+    <string name="azar">قوس</string>
+    <string name="dey">جدی</string>
+    <string name="bahman">دلو</string>
+    <string name="esfand">حوت</string>
+
+    <string name="shanbeh">شنبه</string>
+    <string name="yekshanbeh">یکشنبه</string>
+    <string name="doshanbeh">دوشنبه</string>
+    <string name="sehshanbeh">سه‌شنبه</string>
+    <string name="chaharshanbeh">چهارشنبه</string>
+    <string name="panjshanbeh">پنج‌شنبه</string>
+    <string name="jome">جمعه</string>
+
+</resources>

--- a/persiandatepicker/src/main/res/values-fa/strings.xml
+++ b/persiandatepicker/src/main/res/values-fa/strings.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="farvardin">فروردین</string>
+    <string name="ordibehesht">اُردیبهشت</string>
+    <string name="khordad">خرداد</string>
+    <string name="tir">تیر</string>
+    <string name="mordad">مرداد</string>
+    <string name="shahrivar">شهریور</string>
+    <string name="mehr">مهر</string>
+    <string name="aban">آبان</string>
+    <string name="azar">آذر</string>
+    <string name="dey">دی</string>
+    <string name="bahman">بهمن</string>
+    <string name="esfand">اسفند</string>
+
+    <string name="shanbeh">شنبه</string>
+    <string name="yekshanbeh">یکشنبه</string>
+    <string name="doshanbeh">دوشنبه</string>
+    <string name="sehshanbeh">سه‌شنبه</string>
+    <string name="chaharshanbeh">چهارشنبه</string>
+    <string name="panjshanbeh">پنج‌شنبه</string>
+    <string name="jome">جمعه</string>
+
+</resources>

--- a/persiandatepicker/src/main/res/values-ps/strings.xml
+++ b/persiandatepicker/src/main/res/values-ps/strings.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">PersianDatePicker</string>
+
+    <string name="farvardin">حمل</string>
+    <string name="ordibehesht">ثور</string>
+    <string name="khordad">جوزا</string>
+    <string name="tir">سرطان</string>
+    <string name="mordad">اسد</string>
+    <string name="shahrivar">سنبله</string>
+    <string name="mehr">میزان</string>
+    <string name="aban">عقرب</string>
+    <string name="azar">قوس</string>
+    <string name="dey">جدی</string>
+    <string name="bahman">دلو</string>
+    <string name="esfand">حوت</string>
+
+
+    <string name="shanbeh">خالی</string>
+    <string name="yekshanbeh">دوهم</string>
+    <string name="doshanbeh">ګول</string>
+    <string name="sehshanbeh">نهه</string>
+    <string name="chaharshanbeh">شروع</string>
+    <string name="panjshanbeh">زیارت</string>
+    <string name="jome">جمعه</string>
+</resources>

--- a/persiandatepicker/src/main/res/values/strings.xml
+++ b/persiandatepicker/src/main/res/values/strings.xml
@@ -1,25 +1,25 @@
 <resources>
     <string name="app_name">PersianDatePicker</string>
 
-    <string name="farvardin">farvardin</string>
-    <string name="ordibehesht">ordibehesht</string>
-    <string name="khordad">khordad</string>
-    <string name="tir">tir</string>
-    <string name="mordad">mordad</string>
-    <string name="shahrivar">shahrivar</string>
-    <string name="mehr">mehr</string>
-    <string name="aban">aban</string>
-    <string name="azar">azar</string>
-    <string name="dey">dey</string>
-    <string name="bahman">bahman</string>
-    <string name="esfand">esfand</string>
+    <string name="farvardin">Farvardin</string>
+    <string name="ordibehesht">Ordibehesht</string>
+    <string name="khordad">Khordad</string>
+    <string name="tir">Tir</string>
+    <string name="mordad">Mordad</string>
+    <string name="shahrivar">Shahrivar</string>
+    <string name="mehr">Mehr</string>
+    <string name="aban">Aban</string>
+    <string name="azar">Azar</string>
+    <string name="dey">Dey</string>
+    <string name="bahman">Bahman</string>
+    <string name="esfand">Esfand</string>
 
-    <string name="shanbeh">shanbeh</string>
-    <string name="yekshanbeh">yekshanbeh</string>
-    <string name="doshanbeh">doshanbeh</string>
-    <string name="sehshanbeh">sehshanbeh</string>
-    <string name="chaharshanbeh">chaharshanbeh</string>
-    <string name="panjshanbeh">panjshanbeh</string>
-    <string name="jome">jome</string>
+    <string name="shanbeh">Shanbeh</string>
+    <string name="yekshanbeh">Yekshanbeh</string>
+    <string name="doshanbeh">Doshanbeh</string>
+    <string name="sehshanbeh">Sehshanbeh</string>
+    <string name="chaharshanbeh">Chaharshanbeh</string>
+    <string name="panjshanbeh">Panjshanbeh</string>
+    <string name="jome">Jome</string>
 
 </resources>

--- a/persiandatepicker/src/main/res/values/strings.xml
+++ b/persiandatepicker/src/main/res/values/strings.xml
@@ -1,3 +1,25 @@
 <resources>
     <string name="app_name">PersianDatePicker</string>
+
+    <string name="farvardin">farvardin</string>
+    <string name="ordibehesht">ordibehesht</string>
+    <string name="khordad">khordad</string>
+    <string name="tir">tir</string>
+    <string name="mordad">mordad</string>
+    <string name="shahrivar">shahrivar</string>
+    <string name="mehr">mehr</string>
+    <string name="aban">aban</string>
+    <string name="azar">azar</string>
+    <string name="dey">dey</string>
+    <string name="bahman">bahman</string>
+    <string name="esfand">esfand</string>
+
+    <string name="shanbeh">shanbeh</string>
+    <string name="yekshanbeh">yekshanbeh</string>
+    <string name="doshanbeh">doshanbeh</string>
+    <string name="sehshanbeh">sehshanbeh</string>
+    <string name="chaharshanbeh">chaharshanbeh</string>
+    <string name="panjshanbeh">panjshanbeh</string>
+    <string name="jome">jome</string>
+
 </resources>


### PR DESCRIPTION
Hi,

This library has been great! As Afghanistan is also using the Persian calendar, we wanted to add Dari and Pashto. My colleague @varunasingh have worked on this. We added minor changes so that it uses resource string xml instead of constants. We have then added Farsi, Dari, and Pashto string xml files. 

We hope this can be added to the main repository here so others can make use of it. 

Thanks!
